### PR TITLE
Fixing rotations

### DIFF
--- a/hexpex/hex.py
+++ b/hexpex/hex.py
@@ -195,17 +195,16 @@ class _Hex(ABC):
         if angle % 60 != 0:
             raise ValueError("argument of 'angle' must be in 60 degree increments.")
 
-        rotated = set()
+        rotated = list()
+        # Negative angles return the step count for clockwise rotation so no differntiation needed 
         steps = abs((angle % 360) // 60)
 
         for hex in hexes:
             vector = hex - self
-            if angle > 0:
-                *_, vector = (hex._rotate_clockwise() for _ in range(steps))
-            elif angle < 0:
-                *_, vector = (hex._rotate_counterclockwise() for _ in range(steps))
-            rotated.add(self + vector)
-        return rotated
+            for _ in range(steps):
+                vector = vector._rotate_clockwise()
+            rotated.append(self + vector)
+        return tuple(rotated)
 
     def to_tuple(self) -> tuple[int, ...]:
         """Convert self to tuple representation."""


### PR DESCRIPTION
The rotations were only done once as (hex._rotate_clockwise() for _ in range(steps)) yields the same value over and over again, as hex doesn't change.
The step calculation yields the number of clockwise steps for negative angles, so I removed the distinction (otherwise abs the angle before mod).

Todo: Extend test file. The test didn't catch the issue as it only tests 0° and 60° rotation. Also the use of sets in the testfile allows for a simple change of the angles to also pass the test, as the opposing 120° hex rotations are the same set as 60° rotation. Thus I changed the return type to tuple